### PR TITLE
Upping sip-methods reference to latest version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drachtio-srf",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "description": "drachtio signaling resource framework",
   "main": "lib/srf.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lodash": "^3.10.1",
     "node-noop": "0.0.1",
     "only": "0.0.2",
-    "sip-methods": "^0.2.0",
+    "sip-methods": "^0.3.0",
     "uuid": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
SIP PUBLISH exposure was recently added to drachtio-server and sip-methods. This fixes the reference to the latest sip-methods package so that the API can be accessed.