### PR TITLE
Remove quotation marks from nc and algorithm header parameters when responding to challenge

### DIFF
--- a/lib/digest-client.js
+++ b/lib/digest-client.js
@@ -116,7 +116,11 @@ module.exports = class DigestClient {
   _compileParams(params) {
     const parts = [];
     for (const i in params) {
-      parts.push(i + '="' + params[i] + '"');
+      if (i === 'nc' || i === 'algorithm') {
+        parts.push(i + '=' + params[i]);
+      } else {
+        parts.push(i + '="' + params[i] + '"');
+      }
     }
     return `Digest ${parts.join(',')}`;
   }


### PR DESCRIPTION
feat(digest-client): Comply with RFC2617 HTTP Authentication: Basic and Digest Access Authentication

RFC2617 3.2.2 defines The Authorization Request Header, whose structure specifies that the nc and
algorithm parameter values should not contain quotation marks.  Changed the _compileParams function to remove 'nc' and 'algorithm' parameter values quotation marks when responding to a challenge.