### PR TITLE
if i'm listening for modify, I want all in dialog modifications to cause modify event listener to fire

### DIFF
--- a/lib/dialog.js
+++ b/lib/dialog.js
@@ -358,7 +358,6 @@ class Dialog extends Emitter {
         const refresh = req.body === this.remote.sdp ;
         const hold = origRedacted.replace(/a=sendrecv\r\n/g, 'a=sendonly\r\n') === newRedacted ;
         const unhold = origRedacted.replace(/a=sendonly\r\n/g, 'a=sendrecv\r\n') === newRedacted ;
-        const modify = !hold && !unhold && !refresh ;
         this.remote.sdp = req.body ;
 
         if (refresh) {
@@ -382,7 +381,7 @@ class Dialog extends Emitter {
             }
           }) ;
         }
-        else if (modify) {
+        else {
           this.emit('modify', req, res) ;
         }
         break ;

--- a/lib/dialog.js
+++ b/lib/dialog.js
@@ -372,7 +372,7 @@ class Dialog extends Emitter {
           this.local.sdp = this.local.sdp.replace(/a=recvonly\r\n/g, 'a=sendrecv\r\n') ;
           this.emit('unhold', req) ;
         }
-        if ((refresh || hold || unhold) || (modify && 0 === this.listeners('modify').length)) {
+        if (0 === this.listeners('modify').length) {
           debug('responding with 200 OK to reINVITE') ;
           res.send(200, {
             body: this.local.sdp,


### PR DESCRIPTION
Not expecting this to just be pulled in as is as its a change of behaviour

If I'm modifying the session at all and I have a modify listener I want to know about every in-dialog modification.

In this case I'm passing on the hold/unhold SDP upstream and talking to rtpengine in the middle at the same time. the HOLD sdp is different from the original invite (includes candidates) and so isnt seen as a hold from the code perspective as theres more than just `sendonly` change, unhold is the same sdp as hold except for `sendrecv` so at the moment doesn't trigger the modify callback. 

I think it should!