### PR TITLE
createUAC: Check for colon too in URI

### DIFF
--- a/lib/srf.js
+++ b/lib/srf.js
@@ -351,11 +351,11 @@ class Srf extends Emitter {
 
       const parsed = parser.parseUri(opts.uri) ;
       if (!parsed) {
-        if (-1 === opts.uri.indexOf('@') && 0 !== opts.uri.indexOf('sip')) {
+        if (-1 === opts.uri.indexOf('@') && 0 !== opts.uri.indexOf('sip:')) {
           const address = opts.uri ;
           opts.uri = 'sip:' + (opts.calledNumber ? opts.calledNumber + '@' : '') + address ;
         }
-        else if (0 !== opts.uri.indexOf('sip')) {
+        else if (0 !== opts.uri.indexOf('sip:')) {
           opts.uri = 'sip:' + opts.uri ;
         }
       }
@@ -993,11 +993,11 @@ class Srf extends Emitter {
 
       const parsed = parser.parseUri(opts.uri) ;
       if (!parsed) {
-        if (-1 === opts.uri.indexOf('@') && 0 !== opts.uri.indexOf('sip')) {
+        if (-1 === opts.uri.indexOf('@') && 0 !== opts.uri.indexOf('sip:')) {
           const address = opts.uri ;
           opts.uri = 'sip:' + (opts.calledNumber ? opts.calledNumber + '@' : '') + address ;
         }
-        else if (0 !== opts.uri.indexOf('sip')) {
+        else if (0 !== opts.uri.indexOf('sip:')) {
           opts.uri = 'sip:' + opts.uri ;
         }
       }


### PR DESCRIPTION
Otherwise the mechanism for automatic URI completion would be useless for SIP server names starting with `sip`, like `sip.linphone.org` or `sipfun.tld`.