### PR TITLE
Only apply refresh/hold/unhold logic if these events are subscribed

### DIFF
--- a/lib/dialog.js
+++ b/lib/dialog.js
@@ -359,9 +359,9 @@ class Dialog extends Emitter {
       case 'INVITE':
         const origRedacted = this.remote.sdp.replace(/^o=.*$/m, 'o=REDACTED') ;
         const newRedacted = req.body.replace(/^o=.*$/m, 'o=REDACTED') ;
-        const refresh = req.body === this.remote.sdp ;
-        const hold = origRedacted.replace(/a=sendrecv\r\n/g, 'a=sendonly\r\n') === newRedacted ;
-        const unhold = origRedacted.replace(/a=sendonly\r\n/g, 'a=sendrecv\r\n') === newRedacted ;
+        const refresh = req.body === this.remote.sdp && this.listeners('refresh').length > 0;
+        const hold = origRedacted.replace(/a=sendrecv\r\n/g, 'a=sendonly\r\n') === newRedacted && this.listeners('hold').length > 0;
+        const unhold = origRedacted.replace(/a=sendonly\r\n/g, 'a=sendrecv\r\n') === newRedacted && this.listeners('unhold').length > 0;
         const modify = !hold && !unhold && !refresh ;
         this.remote.sdp = req.body ;
 


### PR DESCRIPTION
As talked about in issue #59 here is a PR that'll disable the refresh/hold/unhold logic unless these events are subscribed by the implementor.

The refresh, hold and unhold events aren't mentioned in the documentation, so the number of people implicitly relying on this logic is probably fairly limited (?). In any case, this of course would break existing logic, so if you'd like it to be implemented differently, let me know!

The purpose for me in this case, is to make sure I get full control of any reinvites and their SDP.