### PR TITLE
on response to Challenge(401 or 407), QOP should be without quotes.

### DIFF
--- a/lib/digest-client.js
+++ b/lib/digest-client.js
@@ -126,7 +126,7 @@ module.exports = class DigestClient {
   _compileParams(params) {
     const parts = [];
     for (const i in params) {
-      if (['nc', 'algorithm'].includes(i)) parts.push(`${i}=${params[i]}`);
+      if (['nc', 'algorithm', 'qop'].includes(i)) parts.push(`${i}=${params[i]}`);
       else parts.push(`${i}="${params[i]}"`);
     }
     return `Digest ${parts.join(',')}`;


### PR DESCRIPTION
As per auth challenge, We need QOP without quotes.
https://tools.ietf.org/html/draft-smith-sipping-auth-examples-01