### PR TITLE
Add support for name in header From

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -283,6 +283,7 @@ delegate(Request.prototype, 'msg')
   .getter('type')
   .getter('raw')
   .getter('callingNumber')
+  .getter('callingName')
   .getter('calledNumber')
   .getter('canFormDialog') ;
 

--- a/lib/srf.js
+++ b/lib/srf.js
@@ -381,10 +381,20 @@ class Srf extends Emitter {
         }
       }
 
+      let from = undefined;
+
       if (opts.callingNumber) {
-        opts.headers.from = `sip:${opts.callingNumber}@localhost` ;
+        if (opts.callingName) {
+          from = `"${opts.callingName}" <sip:${opts.callingNumber}@localhost>`;
+        } else {
+          from = `sip:${opts.callingNumber}@localhost`;
+        }
+      }
+
+      if (from) {
+        opts.headers.from = from;
         if (!opts.headers.contact && !opts.headers.Contact) {
-          opts.headers.contact = `sip:${opts.callingNumber}@localhost` ;
+          opts.headers.contact = from;
         }
       }
 
@@ -682,6 +692,7 @@ class Srf extends Emitter {
     else proxyRequestHeaders.forEach((hdr) => { if (req.has(hdr)) opts.headers[hdr] = req.get(hdr);}) ;
 
     if (!(opts.headers.from || opts.headers.From) && !opts.callingNumber) { opts.callingNumber = req.callingNumber; }
+    if (!(opts.headers.from || opts.headers.From) && !opts.callingName) { opts.callingName = req.callingName; }
     if (!(opts.headers.to || opts.headers.To) && !opts.calledNumber) { opts.calledNumber = req.calledNumber; }
 
     opts.localSdp = opts.localSdpB || req.body ;


### PR DESCRIPTION
Hi @davehorton 
 
I was using the function createB2BUA and notice that when the contact name was defined in the From header the srf transformed that value and the original header was not propagated to the server-side.

I made this PR to correct this behavior on the side of the srf.

I also made PR to support this on the side of the drachtio-sip module.

https://github.com/davehorton/drachtio-sip/pull/5

Tell me what you think.

Best regards.